### PR TITLE
Add a protocol by default on config endpoint

### DIFF
--- a/src/Kitar/Dynamodb/Connection.php
+++ b/src/Kitar/Dynamodb/Connection.php
@@ -79,7 +79,7 @@ class Connection extends BaseConnection
             'endpoint' => $config['endpoint'] ?? null,
         ];
 
-        if(preg_match('#^https?://#i', $dynamoConfig['endpoint']) === 0){
+        if (! empty($dynamoConfig['endpoint']) && preg_match('#^https?://#i', $dynamoConfig['endpoint']) === 0) {
             $dynamoConfig['endpoint'] = "https://" . $dynamoConfig['endpoint'];
         }
 

--- a/src/Kitar/Dynamodb/Connection.php
+++ b/src/Kitar/Dynamodb/Connection.php
@@ -79,6 +79,10 @@ class Connection extends BaseConnection
             'endpoint' => $config['endpoint'] ?? null,
         ];
 
+        if(preg_match('#^https?://#i', $dynamoConfig['endpoint']) === 0){
+            $dynamoConfig['endpoint'] = "https://" . $dynamoConfig['endpoint'];
+        }
+
         if ($key = $config['access_key'] ?? null) {
             $config['key'] = $key;
             unset($config['access_key']);

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -96,4 +96,30 @@ class ConnectionTest extends TestCase
             'TableName' => 'User'
         ]);
     }
+
+    /** @test */
+    public function it_prepends_default_protocol_if_not_given()
+    {
+        $connection = new Connection(['endpoint' => 'examples.com']);
+        $this->assertEquals($connection->getClient()->getEndpoint()->getScheme(), 'https');
+        $this->assertEquals($connection->getClient()->getEndpoint()->getHost(), 'examples.com');
+        $this->assertEquals($this->connection->getClient()->getEndpoint()->getScheme(), 'https');
+        $this->assertEquals($this->connection->getClient()->getEndpoint()->getHost(), 'dynamodb.us-east-1.amazonaws.com');
+    }
+
+    /** @test */
+    public function it_dont_prepends_default_protocol_if_http_given()
+    {
+        $connection = new Connection(['endpoint' => 'http://examples.com']);
+        $this->assertEquals($connection->getClient()->getEndpoint()->getScheme(), 'http');
+        $this->assertEquals($connection->getClient()->getEndpoint()->getHost(), 'examples.com');
+    }
+
+    /** @test */
+    public function it_dont_prepends_default_protocol_if_https_given()
+    {
+        $connection = new Connection(['endpoint' => 'https://examples.com']);
+        $this->assertEquals($connection->getClient()->getEndpoint()->getScheme(), 'https');
+        $this->assertEquals($connection->getClient()->getEndpoint()->getHost(), 'examples.com');
+    }
 }


### PR DESCRIPTION
This PR closes #18.

When you set `DYNAMODB_ENDPOINT` without a protocol, for example: `dynamodb.eu-west-1.amazonaws.com` the AWS SDK throws an error.

This PR adds a protocol by default on the endpoint config, if not present, to avoid this situation.