### PR TITLE
Fix return types

### DIFF
--- a/src/Kitar/Dynamodb/Model/Model.php
+++ b/src/Kitar/Dynamodb/Model/Model.php
@@ -122,7 +122,7 @@ class Model extends BaseModel
      * Get all of the models from the database.
      *
      * @param  array $columns
-     * @return Illuminate\Database\Eloquent\Collection
+     * @return \Illuminate\Database\Eloquent\Collection
      */
     public static function all($columns = [])
     {

--- a/src/Kitar/Dynamodb/Model/Model.php
+++ b/src/Kitar/Dynamodb/Model/Model.php
@@ -110,7 +110,7 @@ class Model extends BaseModel
         }
 
         if (is_string($key) || is_numeric($key)) {
-            $model = new static;
+            $model = new static();
             $model->setAttribute($model->getKeyName(), $key);
             $key = $model->getKey();
         }

--- a/src/Kitar/Dynamodb/Query/Builder.php
+++ b/src/Kitar/Dynamodb/Query/Builder.php
@@ -522,7 +522,7 @@ class Builder extends BaseBuilder
     protected function process($query_method, $processor_method)
     {
         // Compile columns and wheres attributes.
-        // These attributes needs to intaract with ExpressionAttributes during compile,
+        // These attributes needs to interact with ExpressionAttributes during compile,
         // so it need to run before compileExpressionAttributes.
         $params = array_merge(
             $this->grammar->compileProjectionExpression($this->columns, $this->expression_attributes),

--- a/src/Kitar/Dynamodb/Query/Builder.php
+++ b/src/Kitar/Dynamodb/Query/Builder.php
@@ -14,7 +14,6 @@ use Illuminate\Database\Query\Builder as BaseBuilder;
 
 class Builder extends BaseBuilder
 {
-
     /**
      * Name of the index.
      * @var string|null
@@ -125,7 +124,7 @@ class Builder extends BaseBuilder
 
         $this->processor = $processor;
 
-        $this->expression_attributes = $expression_attributes ?? new ExpressionAttributes;
+        $this->expression_attributes = $expression_attributes ?? new ExpressionAttributes();
 
         if (! $is_nested_query) {
             $this->initializeDedicatedQueries();

--- a/src/Kitar/Dynamodb/Query/Builder.php
+++ b/src/Kitar/Dynamodb/Query/Builder.php
@@ -91,29 +91,29 @@ class Builder extends BaseBuilder
 
     /**
      * Dedicated query for building FilterExpression.
-     * @var Kitar\Dynamodb\Query\Builder
+     * @var \Kitar\Dynamodb\Query\Builder
      */
     protected $filter_query;
 
     /**
      * Dedicated query for building ConditionExpression.
-     * @var Kitar\Dynamodb\Query\Builder
+     * @var \Kitar\Dynamodb\Query\Builder
      */
     protected $condition_query;
 
     /**
      * Dedicated query for building KeyConditionExpression.
-     * @var Kitar\Dynamodb\Query\Builder
+     * @var \Kitar\Dynamodb\Query\Builder
      */
     protected $key_condition_query;
 
     /**
      * Create a new query builder instance.
      *
-     * @param Kitar\Dynamodb\Connection $connection
-     * @param Kitar\Dynamodb\Query\Grammar $grammar
-     * @param Kitar\Dynamodb\Query\Processor $processor
-     * @param Kitar\Dynamodb\Query\ExpressionAttributes|null $expression_attributes
+     * @param \Kitar\Dynamodb\Connection $connection
+     * @param \Kitar\Dynamodb\Query\Grammar $grammar
+     * @param \Kitar\Dynamodb\Query\Processor $processor
+     * @param \Kitar\Dynamodb\Query\ExpressionAttributes|null $expression_attributes
      * @param bool $is_nested_query
      * @return void
      */
@@ -336,7 +336,7 @@ class Builder extends BaseBuilder
      * @param $symbol
      * @param int $amount
      * @param array $extra
-     * @return array|\Aws\Result|Aws\Result|Illuminate\Support\Collection
+     * @return array|\Aws\Result|Aws\Result|\Illuminate\Support\Collection
      */
     protected function incrementOrDecrement($column, $symbol, $amount = 1, array $extra = [])
     {
@@ -350,7 +350,7 @@ class Builder extends BaseBuilder
     /**
      * Query.
      *
-     * @return Illuminate\Support\Collection|array
+     * @return \Illuminate\Support\Collection|array
      */
     public function query()
     {
@@ -361,7 +361,7 @@ class Builder extends BaseBuilder
      * Scan.
      *
      * @param  array $columns
-     * @return Illuminate\Support\Collection|array
+     * @return \Illuminate\Support\Collection|array
      */
     public function scan($columns = [])
     {
@@ -518,7 +518,7 @@ class Builder extends BaseBuilder
      * @param string $query_method
      * @param array $params
      * @param string $processor_method
-     * @return array|Illuminate\Support\Collection|Aws\Result
+     * @return array|\Illuminate\Support\Collection|\Aws\Result
      */
     protected function process($query_method, $processor_method)
     {


### PR DESCRIPTION
- Fixes return types to be fully qualified to enable code analysers to check return types properly.
  Example running phpstan level 9:
  ```
  20     Access to offset 0 on an unknown class Kitar\Dynamodb\Model\Illuminate\Database\Eloquent\Collection.                                                                                        
         💡 Learn more at https://phpstan.org/user-guide/discovering-symbols      
  ```
- Implement PSR coding standards for new objects.
- Fix typo on comment