### PR TITLE
Add batch write item

### DIFF
--- a/src/Kitar/Dynamodb/Query/Builder.php
+++ b/src/Kitar/Dynamodb/Query/Builder.php
@@ -550,7 +550,7 @@ class Builder extends BaseBuilder
             $this->grammar->compileIndexName($this->index),
             $this->grammar->compileKey($this->key),
             $this->grammar->compileItem($this->item),
-            $this->grammar->compileBatchWrite($this->batchItems, $this->from),
+            $this->grammar->compileBatchWrite($this->batchItems, $this->grammar->getTablePrefix() . $this->from),
             $this->grammar->compileUpdates($this->updates),
             $this->grammar->compileDynamodbLimit($this->limit),
             $this->grammar->compileScanIndexForward($this->scan_index_forward),

--- a/src/Kitar/Dynamodb/Query/Builder.php
+++ b/src/Kitar/Dynamodb/Query/Builder.php
@@ -550,7 +550,7 @@ class Builder extends BaseBuilder
             $this->grammar->compileIndexName($this->index),
             $this->grammar->compileKey($this->key),
             $this->grammar->compileItem($this->item),
-            $this->grammar->compileBatchWrite($this->batchItems, $this->tablePrefix . $this->from),
+            $this->grammar->compileBatchWrite($this->batchItems, $this->from),
             $this->grammar->compileUpdates($this->updates),
             $this->grammar->compileDynamodbLimit($this->limit),
             $this->grammar->compileScanIndexForward($this->scan_index_forward),

--- a/src/Kitar/Dynamodb/Query/Builder.php
+++ b/src/Kitar/Dynamodb/Query/Builder.php
@@ -33,6 +33,11 @@ class Builder extends BaseBuilder
     public $item = [];
 
     /**
+     * Items array for batch insert.
+     */
+    public $batchItems = [];
+
+    /**
      * The key/values to update.
      * @var array
      */
@@ -272,6 +277,13 @@ class Builder extends BaseBuilder
         $this->item = $item;
 
         return $this->process('putItem', null);
+    }
+
+    public function batchWriteItems(array $items)
+    {
+        $this->batchItems = $items;
+
+        return $this->process('batchWriteItems', null);
     }
 
     /**

--- a/src/Kitar/Dynamodb/Query/Builder.php
+++ b/src/Kitar/Dynamodb/Query/Builder.php
@@ -550,6 +550,7 @@ class Builder extends BaseBuilder
             $this->grammar->compileIndexName($this->index),
             $this->grammar->compileKey($this->key),
             $this->grammar->compileItem($this->item),
+            $this->grammar->compileBatchWrite($this->batchItems, $this->tablePrefix . $this->from),
             $this->grammar->compileUpdates($this->updates),
             $this->grammar->compileDynamodbLimit($this->limit),
             $this->grammar->compileScanIndexForward($this->scan_index_forward),

--- a/src/Kitar/Dynamodb/Query/Builder.php
+++ b/src/Kitar/Dynamodb/Query/Builder.php
@@ -283,7 +283,7 @@ class Builder extends BaseBuilder
     {
         $this->batchItems = $items;
 
-        return $this->process('batchWriteItems', null);
+        return $this->process('batchWriteItems', 'processMultipleBatchItems');
     }
 
     /**

--- a/src/Kitar/Dynamodb/Query/Grammar.php
+++ b/src/Kitar/Dynamodb/Query/Grammar.php
@@ -107,10 +107,8 @@ class Grammar extends BaseGrammer
 
         return [
             'RequestItems' => [
-                $tableName => [
-                    $insert
-                ]
-            ]
+                $tableName => $insert,
+            ],
         ];
     }
 

--- a/src/Kitar/Dynamodb/Query/Grammar.php
+++ b/src/Kitar/Dynamodb/Query/Grammar.php
@@ -91,6 +91,29 @@ class Grammar extends BaseGrammer
         ];
     }
 
+    public function compileBatchWrite(array $items, string $tableName)
+    {
+        if (empty($items)) {
+            return [];
+        }
+
+        $insert = [];
+
+        foreach ($items as $item) {
+            $insert[] = [
+                'PutRequest' => $this->compileItem($item)
+            ];
+        }
+
+        return [
+            'RequestItems' => [
+                $tableName => [
+                    $insert
+                ]
+            ]
+        ];
+    }
+
     /**
      * Compile the Item attribute.
      *

--- a/src/Kitar/Dynamodb/Query/Processor.php
+++ b/src/Kitar/Dynamodb/Query/Processor.php
@@ -78,4 +78,28 @@ class Processor extends BaseProcessor
             return $item;
         });
     }
+
+    public function processMultipleBatchItems(Result $awsResponse, $modelClass = null)
+    {
+        $response = $this->unmarshal($awsResponse);
+
+        if (empty($modelClass)) {
+            return $response;
+        }
+
+        $items = collect();
+        $model = new $modelClass;
+
+        foreach ($response['UnprocessedItems'][$model->getTable()] as $item) {
+            $item = $model->newFromBuilder($item['Item']);
+            $items->push($item);
+        }
+
+        unset($response['UnprocessedItems']);
+
+        return $items->map(function ($item) use ($response) {
+            $item->setMeta($response);
+            return $item;
+        });
+    }
 }

--- a/src/Kitar/Dynamodb/Query/Processor.php
+++ b/src/Kitar/Dynamodb/Query/Processor.php
@@ -91,7 +91,7 @@ class Processor extends BaseProcessor
         $items = collect();
         $model = new $modelClass;
 
-        foreach ($response['UnprocessedItems'][Str::singular(Str::ucfirst($model->getTable()))] as $item) {
+        foreach ($response['UnprocessedItems'][$model->getTable()] as $item) {
             $item = $model->newFromBuilder($item['PutRequest']['Item']);
             $items->push($item);
         }

--- a/src/Kitar/Dynamodb/Query/Processor.php
+++ b/src/Kitar/Dynamodb/Query/Processor.php
@@ -5,6 +5,7 @@ namespace Kitar\Dynamodb\Query;
 use Aws\Result;
 use Aws\DynamoDb\Marshaler;
 use Illuminate\Database\Query\Processors\Processor as BaseProcessor;
+use Illuminate\Support\Str;
 
 class Processor extends BaseProcessor
 {
@@ -90,8 +91,8 @@ class Processor extends BaseProcessor
         $items = collect();
         $model = new $modelClass;
 
-        foreach ($response['UnprocessedItems'][$model->getTable()] as $item) {
-            $item = $model->newFromBuilder($item['Item']);
+        foreach ($response['UnprocessedItems'][Str::singular(Str::ucfirst($model->getTable()))] as $item) {
+            $item = $model->newFromBuilder($item['PutRequest']['Item']);
             $items->push($item);
         }
 

--- a/tests/Query/ProcessorTest.php
+++ b/tests/Query/ProcessorTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\TestCase;
 
 class User extends Model
 {
+    protected $table = 'User';
 }
 
 class ProcessorTest extends TestCase
@@ -26,7 +27,7 @@ class ProcessorTest extends TestCase
         'multiple_items_empty_processed' => '{"Items":[],"Count":0,"ScannedCount":2,"@metadata":{"statusCode":200,"effectiveUri":"https:\/\/dynamodb.ap-northeast-1.amazonaws.com","transferStats":{"http":[[]]}}}',
         'multiple_batch_items_empty_result' => '{"UnprocessedItems":{"Category":[]},"ConsumedCapacity":[{"TableName":"Forum","CapacityUnits":3}]}',
         'multiple_batch_items_empty_processed' => '{"UnprocessedItems":{"Category":[]},"ConsumedCapacity":[{"TableName":"Forum","CapacityUnits":3}]}',
-        'multiple_batch_items_single_unprocessed' => '{"UnprocessedItems":{"User":[{"PutRequest":{"Item":{"Name":{"S":"Amazon ElastiCache"},"Category":{"S":"Amazon Web Services"}}}}]},"ConsumedCapacity":[{"TableName":"Forum","CapacityUnits":3}]}',
+        'multiple_batch_items_single_processed' => '{"UnprocessedItems":{"User":[{"PutRequest":{"Item":{"Name":{"S":"Amazon ElastiCache"},"Category":{"S":"Amazon Web Services"}}}}]},"ConsumedCapacity":[{"TableName":"Forum","CapacityUnits":3}]}',
     ];
 
     protected function setUp() :void
@@ -132,7 +133,7 @@ class ProcessorTest extends TestCase
     /** @test */
     public function it_can_convert_unprocessed_results_to_model_instance()
     {
-        $awsResult = new Result(json_decode($this->mocks['multiple_batch_items_single_unprocessed'], true));
+        $awsResult = new Result(json_decode($this->mocks['multiple_batch_items_single_processed'], true));
 
         $items = $this->processor->processMultipleBatchItems($awsResult, User::class);
 

--- a/tests/Query/ProcessorTest.php
+++ b/tests/Query/ProcessorTest.php
@@ -23,7 +23,9 @@ class ProcessorTest extends TestCase
         'multiple_items_result' => '{"Items":[{"Category":{"S":"Amazon Web Services"},"Name":{"S":"Amazon S3"}},{"Threads":{"N":"2"},"Category":{"S":"Amazon Web Services"},"Messages":{"N":"4"},"Views":{"N":"1000"},"Name":{"S":"Amazon DynamoDB"}}],"Count":2,"ScannedCount":2,"@metadata":{"statusCode":200,"effectiveUri":"https:\/\/dynamodb.ap-northeast-1.amazonaws.com","transferStats":{"http":[[]]}}}',
         'multiple_items_processed' => '{"Items":[{"Category":"Amazon Web Services","Name":"Amazon S3"},{"Threads":2,"Category":"Amazon Web Services","Messages":4,"Views":1000,"Name":"Amazon DynamoDB"}],"Count":2,"ScannedCount":2,"@metadata":{"statusCode":200,"effectiveUri":"https:\/\/dynamodb.ap-northeast-1.amazonaws.com","transferStats":{"http":[[]]}}}',
         'multiple_items_empty_result' => '{"Items":[],"Count":0,"ScannedCount":2,"@metadata":{"statusCode":200,"effectiveUri":"https:\/\/dynamodb.ap-northeast-1.amazonaws.com","transferStats":{"http":[[]]}}}',
-        'multiple_items_empty_processed' => '{"Items":[],"Count":0,"ScannedCount":2,"@metadata":{"statusCode":200,"effectiveUri":"https:\/\/dynamodb.ap-northeast-1.amazonaws.com","transferStats":{"http":[[]]}}}'
+        'multiple_items_empty_processed' => '{"Items":[],"Count":0,"ScannedCount":2,"@metadata":{"statusCode":200,"effectiveUri":"https:\/\/dynamodb.ap-northeast-1.amazonaws.com","transferStats":{"http":[[]]}}}',
+        'multiple_batch_items_empty_result' => '{"UnprocessedItems":{"Category":[]},"ConsumedCapacity":[{"TableName":"Forum","CapacityUnits":3}]}',
+        'multiple_batch_items_empty_processed' => '{"UnprocessedItems":{"Category":[]},"ConsumedCapacity":[{"TableName":"Forum","CapacityUnits":3}]}',
     ];
 
     protected function setUp() :void
@@ -112,5 +114,17 @@ class ProcessorTest extends TestCase
             'Name' => 'Amazon S3'
         ], $item->toArray());
         $this->assertEquals(200, $item->meta()['@metadata']['statusCode']);
+    }
+
+    /** @test */
+    public function it_can_process_multiple_batch_items_empty_result()
+    {
+        $expected = json_decode($this->mocks['multiple_batch_items_empty_processed'], true);
+
+        $awsResult = new Result(json_decode($this->mocks['multiple_batch_items_empty_result'], true));
+
+        $items = $this->processor->processMultipleBatchItems($awsResult, null);
+
+        $this->assertEquals($expected, $items);
     }
 }

--- a/tests/Query/ProcessorTest.php
+++ b/tests/Query/ProcessorTest.php
@@ -26,6 +26,7 @@ class ProcessorTest extends TestCase
         'multiple_items_empty_processed' => '{"Items":[],"Count":0,"ScannedCount":2,"@metadata":{"statusCode":200,"effectiveUri":"https:\/\/dynamodb.ap-northeast-1.amazonaws.com","transferStats":{"http":[[]]}}}',
         'multiple_batch_items_empty_result' => '{"UnprocessedItems":{"Category":[]},"ConsumedCapacity":[{"TableName":"Forum","CapacityUnits":3}]}',
         'multiple_batch_items_empty_processed' => '{"UnprocessedItems":{"Category":[]},"ConsumedCapacity":[{"TableName":"Forum","CapacityUnits":3}]}',
+        'multiple_batch_items_single_unprocessed' => '{"UnprocessedItems":{"User":[{"PutRequest":{"Item":{"Name":{"S":"Amazon ElastiCache"},"Category":{"S":"Amazon Web Services"}}}}]},"ConsumedCapacity":[{"TableName":"Forum","CapacityUnits":3}]}',
     ];
 
     protected function setUp() :void
@@ -126,5 +127,25 @@ class ProcessorTest extends TestCase
         $items = $this->processor->processMultipleBatchItems($awsResult, null);
 
         $this->assertEquals($expected, $items);
+    }
+
+    /** @test */
+    public function it_can_convert_unprocessed_results_to_model_instance()
+    {
+        $awsResult = new Result(json_decode($this->mocks['multiple_batch_items_single_unprocessed'], true));
+
+        $items = $this->processor->processMultipleBatchItems($awsResult, User::class);
+
+        $item = $items->first();
+
+        $this->assertEquals(User::class, get_class($item));
+        $this->assertEquals([
+            'Category' => [
+                'S' => 'Amazon Web Services'
+            ],
+            'Name' => [
+                'S' =>'Amazon ElastiCache'
+            ]
+        ], $item->toArray());
     }
 }


### PR DESCRIPTION
**---> DRAFT PULL REQUEST <---**

**Description**

Starting to work on a implentation for batch writing items.
This is to gain a lot of performance when inserting many items.

Let's see if this can be done in a clean way.

Please feel free to join in 😄 

**Notes:** 
- BatchWriteItem only supports insert of 25 items at a time - so probably something needs to check that.
- BatchWriteItem does not support updates
- The model layer don't understand "saveMany" in one go, so the query builder has to implement it.

**Documentation**
https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_BatchWriteItem.html