### PR TITLE
Marshal values before batch writing

### DIFF
--- a/src/Kitar/Dynamodb/Query/Builder.php
+++ b/src/Kitar/Dynamodb/Query/Builder.php
@@ -146,7 +146,7 @@ class Builder extends BaseBuilder
 
         $this->expression_attributes = $expression_attributes ?? new ExpressionAttributes();
 
-        $this->marshaller = new Marshaller();
+        $this->marshaller = new Marshaler();
 
         if (! $is_nested_query) {
             $this->initializeDedicatedQueries();

--- a/tests/Query/BuilderTest.php
+++ b/tests/Query/BuilderTest.php
@@ -781,10 +781,18 @@ class BuilderTest extends TestCase
                         'PutRequest' => [
                             'Item' => [
                                 'ForumName' => [
-                                    'S' => 'Amazon DynamoDB'
+                                    'M' => [
+                                        'S' => [
+                                            'S' => 'Amazon DynamoDB'
+                                        ]
+                                    ],
                                 ],
                                 'Subject' => [
-                                    'S' => 'DynamoDB Thread 3'
+                                    'M' => [
+                                        'S' => [
+                                            'S' =>  'DynamoDB Thread 3'
+                                        ]
+                                    ]
                                 ]
                             ]
                         ]
@@ -793,10 +801,18 @@ class BuilderTest extends TestCase
                         'PutRequest' => [
                             'Item' => [
                                 'ForumName' => [
-                                    'S' => 'Amazon DynamoDB'
+                                    'M' => [
+                                        'S' => [
+                                            'S' => 'Amazon DynamoDB',
+                                        ]
+                                    ],
                                 ],
                                 'Subject' => [
-                                    'S' => 'DynamoDB Thread 4'
+                                    'M' => [
+                                        'S' => [
+                                            'S' => 'DynamoDB Thread 4'
+                                        ]
+                                    ]
                                 ]
                             ]
                         ]


### PR DESCRIPTION
**NOT TESTET**

This is pretty hard to test. Yesterday i changed our internal systems to use the kitar version of batch write items, instead of our own implementation. We are doing aprox 50.000 writes a day, and we began to see some errors where the structure is not valid for batch write items. So i compared our solution wiith the one in Kitar - and the only difference i can see is that we were marshalling.

Here' the error we got:
![image](https://user-images.githubusercontent.com/2228675/209472514-28c2a792-0972-4ab6-b3ff-3184f0b86d78.png)

Left this as a draft - to start a coversation 😄 
