### PR TITLE
Support for Laravel 10 and PHPUnit 10.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,18 +21,18 @@
     },
     "require": {
         "php": "^7.3|^7.4|^8.0|^8.1|^8.2",
-        "illuminate/support": "^6.0|^7.0|^8.0|^9.0",
-        "illuminate/container": "^6.0|^7.0|^8.0|^9.0",
-        "illuminate/database": "^6.0|^7.0|^8.0|^9.0",
-        "illuminate/hashing": "^6.0|^7.0|^8.0|^9.0",
+        "illuminate/support": "^6.0|^7.0|^8.0|^9.0|^10.0",
+        "illuminate/container": "^6.0|^7.0|^8.0|^9.0|^10.0",
+        "illuminate/database": "^6.0|^7.0|^8.0|^9.0|^10.0",
+        "illuminate/hashing": "^6.0|^7.0|^8.0|^9.0|^10.0",
         "aws/aws-sdk-php": "^3.0"
     },
     "require-dev": {
-        "illuminate/auth": "^6.0|^7.0|^8.0|^9.0",
-        "symfony/var-dumper": "^5.0",
-        "vlucas/phpdotenv": "^4.1",
+        "illuminate/auth": "^6.0|^7.0|^8.0|^9.0|^10.0",
+        "symfony/var-dumper": "^5.0|^6.0",
+        "vlucas/phpdotenv": "^4.1|^5.0",
         "mockery/mockery": "^1.3",
-        "phpunit/phpunit": "^8.0|^9.0"
+        "phpunit/phpunit": "^8.0|^9.0|^10.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This opens the possibility to install laravel-dynamodb together with Laravel 10, and PHPunit 10.

