### PR TITLE
Error with the Dynamo Pagination

### DIFF
--- a/src/Kitar/Dynamodb/Helpers/Collection.php
+++ b/src/Kitar/Dynamodb/Helpers/Collection.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Kitar\Dynamodb\Helpers;
+
+use Illuminate\Support\Collection as BaseCollection;
+
+class Collection extends BaseCollection
+{
+    /**
+     * @var array
+     */
+    private $meta;
+
+    /**
+     * @param  array  $meta
+     * @return $this
+     */
+    public function setMeta($meta)
+    {
+        $this->meta = $meta;
+
+        return $this;
+    }
+
+    /**
+     * Get meta data.
+     */
+    public function getMeta()
+    {
+        return $this->meta;
+    }
+
+    /**
+     * Get LastEvaluatedKey from meta
+     */
+    public function getLastEvaluatedKey()
+    {
+        return $this->meta['LastEvaluatedKey'] ?? null;
+    }
+}


### PR DESCRIPTION
This PR will fix last evaluated key when the collection is empty and we can still have results at the dynamo.

When the result don't contain any itens, but we still have a lastEvaluatedKey at the Dynamo response, this means that we still has to confirm if we have or not values at the dynamo.

The function processMultipleItems at the processor was adding the meta at the collection items.

To solve this it was extended the Laravel Collection and created a new attribute to add the meta to the collection, so we can access at the  lastEvaluatedKey from the collection instead of the item that don't exist.
