### PR TITLE
Add model `count()` support

### DIFF
--- a/src/Kitar/Dynamodb/Model/Model.php
+++ b/src/Kitar/Dynamodb/Model/Model.php
@@ -343,6 +343,7 @@ class Model extends BaseModel
     {
         $allowedBuilderMethods = [
             "select",
+            "count",
             "take",
             "limit",
             "index",

--- a/src/Kitar/Dynamodb/Query/Builder.php
+++ b/src/Kitar/Dynamodb/Query/Builder.php
@@ -399,7 +399,7 @@ class Builder extends BaseBuilder
         // reset columns selection
         $this->select([])->selectAttributes('COUNT');
 
-        return (int) $this->process('scan', 'processCount');
+        return (int) $this->process('clientQuery', 'processCount');
     }
 
     /**

--- a/src/Kitar/Dynamodb/Query/Grammar.php
+++ b/src/Kitar/Dynamodb/Query/Grammar.php
@@ -47,6 +47,22 @@ class Grammar extends BaseGrammer
     }
 
     /**
+     * Compile the Select attribute.
+     *
+     * @param $select_attributes
+     * @return array
+     */
+    public function compileSelectAttributes($select_attributes) {
+        if ($select_attributes === 'ALL_ATTRIBUTES') {
+            return [];
+        }
+
+        return [
+            'Select' => $select_attributes,
+        ];
+    }
+
+    /**
      * Compile the TableName attribute.
      *
      * @param string $table_name

--- a/src/Kitar/Dynamodb/Query/Processor.php
+++ b/src/Kitar/Dynamodb/Query/Processor.php
@@ -45,6 +45,18 @@ class Processor extends BaseProcessor
         return $responseArray;
     }
 
+    public function processCount(Result $awsResponse, $modelClass = null) {
+        $response = $this->unmarshal($awsResponse);
+
+        if (empty($modelClass)) {
+            return $response;
+        }
+
+        if (! empty($response['Count'])) {
+            return $response['Count'];
+        }
+    }
+
     public function processSingleItem(Result $awsResponse, $modelClass = null)
     {
         $response = $this->unmarshal($awsResponse);


### PR DESCRIPTION
Allow to get a model's count.

DynamoDB allows to specify which attributes will be returned in the query. But also has the special value [COUNT](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Query.html#DDB-Query-request-Select) to get only the count of items.

The used read capacity units is the same as fetching the items, but the payload isn't. In some cases is useful to fetch only the count of items in order to reduce the bandwidth used. It's also useful to bypass the 1MB limit of responses