### PR TITLE
Adding support to local endpoints

### DIFF
--- a/src/Kitar/Dynamodb/Connection.php
+++ b/src/Kitar/Dynamodb/Connection.php
@@ -79,7 +79,11 @@ class Connection extends BaseConnection
             'endpoint' => $config['endpoint'] ?? null,
         ];
 
-        if (! empty($dynamoConfig['endpoint']) && preg_match('#^https?://#i', $dynamoConfig['endpoint']) === 0) {
+        if (
+            ! empty($dynamoConfig['endpoint'])
+            && preg_match('#^https?://#i', $dynamoConfig['endpoint']) === 0
+            && preg_match('#\.[a-z]{2,}$#i', $dynamoConfig['endpoint'])
+        ) {
             $dynamoConfig['endpoint'] = "https://" . $dynamoConfig['endpoint'];
         }
 

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -122,4 +122,23 @@ class ConnectionTest extends TestCase
         $this->assertEquals($connection->getClient()->getEndpoint()->getScheme(), 'https');
         $this->assertEquals($connection->getClient()->getEndpoint()->getHost(), 'examples.com');
     }
+
+    /** @test */
+    public function it_dont_prepends_default_protocol_if_has_local_endpoint()
+    {
+        $connection = new Connection(['endpoint' => 'example-container']);
+        $this->assertEquals($connection->getClient()->getEndpoint()->getScheme(), '');
+        $this->assertEquals($connection->getClient()->getEndpoint()->getHost(), '');
+        $this->assertEquals($connection->getClient()->getEndpoint()->getPath(), 'example-container');
+    }
+
+    /** @test */
+    public function it_dont_prepends_default_protocol_if_has_local_endpoint_with_port()
+    {
+        $connection = new Connection(['endpoint' => 'example-container:8000']);
+        $this->assertEquals($connection->getClient()->getEndpoint()->getScheme(), '');
+        $this->assertEquals($connection->getClient()->getEndpoint()->getHost(), 'example-container');
+        $this->assertEquals($connection->getClient()->getEndpoint()->getPath(), '');
+        $this->assertEquals($connection->getClient()->getEndpoint()->getPort(), 8000);
+    }
 }


### PR DESCRIPTION
When using local endpoints like localhost or the ID of a docker container are passed, https is always appended to the endpoint.

Example of how it is currently happening:

```php
$connection = new Connection(['endpoint' => 'example-container']); // https://example-container
$connection = new Connection(['endpoint' => 'example-container:8000']); // https://example-container:8000
```

This PR prevent it.