### PR TITLE
Improv Laravel compliance

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
   <coverage>
-    <include>
-      <directory suffix=".php">src/</directory>
-    </include>
     <report>
       <clover outputFile="build/logs/clover.xml"/>
       <html outputDirectory="build/html"/>
@@ -16,4 +13,9 @@
     </testsuite>
   </testsuites>
   <logging/>
+  <source>
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+  </source>
 </phpunit>

--- a/src/Kitar/Dynamodb/Concerns/HasMeta.php
+++ b/src/Kitar/Dynamodb/Concerns/HasMeta.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Kitar\Dynamodb\Concerns;
+
+use Illuminate\Support\Arr;
+
+trait HasMeta
+{
+    /**
+     * The @metadata attribute of AWS\Result response.
+     *
+     * @var mixed
+     */
+    protected $meta;
+
+    /**
+     * Get @metadata attribute of AWS\Result response.
+     *
+     * @return mixed
+     */
+    public function meta()
+    {
+        return $this->meta;
+    }
+
+    /**
+     * Set @metadata attribute from AWS\Result response.
+     *
+     * @return mixed
+     */
+    public function setMeta(array $meta)
+    {
+        $this->meta = $meta;
+    }
+
+    /**
+     * Determine if @metadata attribute from AWS\Result response.
+     *
+     * @return mixed
+     */
+    public function hasErrors() {
+        $status = (int) Arr::get($this->meta(), '@metadata.statusCode');
+        return $status >= 200 && $status < 300;
+    }
+}

--- a/src/Kitar/Dynamodb/Connection.php
+++ b/src/Kitar/Dynamodb/Connection.php
@@ -79,7 +79,11 @@ class Connection extends BaseConnection
             'endpoint' => $config['endpoint'] ?? null,
         ];
 
-        if (! empty($dynamoConfig['endpoint']) && preg_match('#^https?://#i', $dynamoConfig['endpoint']) === 0) {
+        if (
+            ! empty($dynamoConfig['endpoint'])
+            && preg_match('#^https?://#i', $dynamoConfig['endpoint']) === 0
+            && preg_match('#\.[a-z]{2,}$#i', $dynamoConfig['endpoint'])
+        ) {
             $dynamoConfig['endpoint'] = "https://" . $dynamoConfig['endpoint'];
         }
 

--- a/src/Kitar/Dynamodb/Exceptions/KeyMissingException.php
+++ b/src/Kitar/Dynamodb/Exceptions/KeyMissingException.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Kitar\Dynamodb\Exceptions;
+
+class KeyMissingException extends \RuntimeException{}

--- a/src/Kitar/Dynamodb/Model/KeyMissingException.php
+++ b/src/Kitar/Dynamodb/Model/KeyMissingException.php
@@ -1,9 +1,0 @@
-<?php
-
-namespace Kitar\Dynamodb\Model;
-
-use RuntimeException;
-
-class KeyMissingException extends RuntimeException
-{
-}

--- a/src/Kitar/Dynamodb/Model/Model.php
+++ b/src/Kitar/Dynamodb/Model/Model.php
@@ -4,47 +4,57 @@ namespace Kitar\Dynamodb\Model;
 
 use Illuminate\Database\Eloquent\Model as BaseModel;
 use Kitar\Dynamodb\Concerns\HasMeta;
+use Kitar\Dynamodb\Query\Builder as QueryBuilder;
 use Kitar\Dynamodb\Exceptions\KeyMissingException;
 
 class Model extends BaseModel
 {
-    /**
-     * The table associated with the model.
-     *
-     * @var string
-     */
-    protected $table;
     use HasMeta;
 
     /**
      * The Partition Key.
+     *
      * @var string
      */
     protected $primaryKey;
 
     /**
      * The Sort Key.
+     *
      * @var string|null
      */
     protected $sortKey;
 
     /**
      * The default value of the Sort Key.
+     *
      * @var string|null
      */
     protected $sortKeyDefault;
 
+    /** LARAVEL Attributies */
     /**
+     * Indicates if the IDs are auto-incrementing.
+     *
+     * @var bool
      */
+    public $incrementing = false;
 
     /**
-     * @inheritdoc
+     * The "type" of the primary key ID
+     *
+     * @var string
      */
+    protected $keyType = 'string';
+
+    /** @inheritdoc */
     public function __construct(array $attributes = [])
     {
-        $this->incrementing = false;
-
-        if ($this->sortKey && $this->sortKeyDefault && ! isset($attributes[$this->sortKey])) {
+        if (
+            $this->sortKey
+            && $this->sortKeyDefault
+            && ! isset($attributes[$this->sortKey])
+        ) {
             $this[$this->sortKey] = $this->sortKeyDefault;
         }
 
@@ -62,38 +72,43 @@ class Model extends BaseModel
             throw new KeyMissingException("Primary (Partition) key is not defined.");
         }
 
-        $key = [];
-
-        $key[$this->primaryKey] = $this->getAttribute($this->primaryKey);
+        $keys = [];
+        $keys[$this->primaryKey] = $this->getAttribute($this->primaryKey);
 
         if ($this->sortKey) {
-            $key[$this->sortKey] = $this->getAttribute($this->sortKey);
+            $keys[$this->sortKey] = $this->getAttribute($this->sortKey);
         }
 
-        $missingKeys = [];
+        $missingKeys = array_keys(array_filter($keys, function ($value) {
+            return !isset($value) || $value === '';
+        }));
 
-        foreach ($key as $name => $value) {
-            if (! isset($value) || $value === '') {
-                $missingKeys[] = $name;
-            }
-        }
-
-        if (! empty($missingKeys)) {
+        if (!empty($missingKeys)) {
             $keyNames = implode(', ', $missingKeys);
             throw new KeyMissingException("Some required key(s) has no value: {$keyNames}");
         }
 
-        return $key;
+        return $keys;
     }
 
-    /**
-     * Get a new query builder for the model's table.
-     *
-     * @return \Kitar\Dynamodb\Query\Builder
-     */
-    public function newQuery()
+    /** @inheritdoc */
+    protected function newBaseQueryBuilder()
     {
-        return $this->getConnection()->table($this->getTable())->usingModel(static::class);
+        $connection = $this->getConnection();
+        $connection->table($this->getTable())->usingModel(static::class);
+
+        return new QueryBuilder(
+            $connection,
+            $connection->getQueryGrammar(),
+            $connection->getPostProcessor()
+        );
+
+    }
+
+    /** @inheritdoc */
+    protected function setKeysForSaveQuery($query)
+    {
+        return $this->newQuery()->key($this->getKey());
     }
 
     /**
@@ -102,6 +117,7 @@ class Model extends BaseModel
      * @param string|array $key
      * @return static|null
      */
+    // TODO: remover/migrar para o builder
     public static function find($key)
     {
         if (empty($key)) {
@@ -120,12 +136,14 @@ class Model extends BaseModel
     /**
      * Get all of the models from the database.
      *
-     * @param  array $columns
-     * @return \Illuminate\Database\Eloquent\Collection
+     * @param  array|string  $columns
+     * @return \Illuminate\Database\Eloquent\Collection<int, static>
      */
     public static function all($columns = [])
     {
-        return static::scan($columns);
+        return static::scan(
+            is_array($columns) ? $columns : func_get_args()
+        );
     }
 
     /**
@@ -135,53 +153,12 @@ class Model extends BaseModel
      * @param  array  $options
      * @return \Kitar\Dynamodb\Model\Model|$this
      */
+    // TODO: migrar para o builder
     public static function create(array $fillables = [], array $options = [])
     {
         $instance = new static($fillables);
         $instance->save($options);
         return $instance;
-    }
-
-    /**
-     * Save the model to the database.
-     *
-     * @param  array  $options
-     * @return bool
-     */
-    public function save(array $options = [])
-    {
-        $query = $this->newQuery();
-
-        // If the "saving" event returns false we'll bail out of the save and return
-        // false, indicating that the save failed. This provides a chance for any
-        // listeners to cancel save operations if validations fail or whatever.
-        if ($this->fireModelEvent('saving') === false) {
-            return false;
-        }
-
-        // If the model already exists in the database we can just update our record
-        // that is already in this database using the current IDs in this "where"
-        // clause to only update this model. Otherwise, we'll just insert them.
-        if ($this->exists) {
-            $saved = $this->isDirty() ?
-                        $this->performUpdate($query) : true;
-        }
-
-        // If the model is brand new, we'll insert it into our database and set the
-        // ID attribute on the model to the value of the newly inserted row's ID
-        // which is typically an auto-increment value managed by the database.
-        else {
-            $saved = $this->performInsert($query);
-        }
-
-        // If the model is successfully saved, we need to do a few more things once
-        // that is done. We will call the "saved" method here to run any actions
-        // we need to happen after a model gets successfully saved right here.
-        if ($saved) {
-            $this->finishSave($options);
-        }
-
-        return $saved;
     }
 
     /**
@@ -208,126 +185,7 @@ class Model extends BaseModel
         });
     }
 
-    /**
-     * Perform a model update operation.
-     *
-     * @param  \Kitar\Dynamodb\Query\Builder  $query
-     * @return bool
-     */
-    protected function performUpdate($query)
-    {
-        // If the updating event returns false, we will cancel the update operation so
-        // developers can hook Validation systems into their models and cancel this
-        // operation if the model does not pass validation. Otherwise, we update.
-        if ($this->fireModelEvent('updating') === false) {
-            return false;
-        }
-
-        // First we need to create a fresh query instance and touch the creation and
-        // update timestamp on the model which are maintained by us for developer
-        // convenience. Then we will just continue saving the model instances.
-        if ($this->usesTimestamps()) {
-            $this->updateTimestamps();
-        }
-
-        // Once we have run the update operation, we will fire the "updated" event for
-        // this model instance. This will allow developers to hook into these after
-        // models are updated, giving them a chance to do any special processing.
-        $dirty = $this->getDirty();
-
-        if (count($dirty) > 0) {
-            $this->newQuery()->key($this->getKey())->updateItem($dirty);
-
-            $this->syncChanges();
-
-            $this->fireModelEvent('updated', false);
-        }
-
-        return true;
-    }
-
-    /**
-     * Perform a model insert operation.
-     *
-     * @param  \Kitar\Dynamodb\Query\Builder  $query
-     * @return bool
-     */
-    protected function performInsert($query)
-    {
-        if ($this->fireModelEvent('creating') === false) {
-            return false;
-        }
-
-        // First we'll need to create a fresh query instance and touch the creation and
-        // update timestamps on this model, which are maintained by us for developer
-        // convenience. After, we will just continue saving these model instances.
-        if ($this->usesTimestamps()) {
-            $this->updateTimestamps();
-        }
-
-        $attributes = $this->getAttributes();
-
-        // If the table isn't incrementing we'll simply insert these attributes as they
-        // are. These attribute arrays must contain an "id" column previously placed
-        // there by the developer as the manually determined key for these models.
-        if (empty($attributes)) {
-            return true;
-        }
-
-        // Prevent overwrites of an existing item.
-        foreach (array_keys($this->getKey()) as $keyName) {
-            $query = $query->condition($keyName, 'attribute_not_exists');
-        }
-
-        $query->putItem($attributes);
-
-        // We will go ahead and set the exists property to true, so that it is set when
-        // the created event is fired, just in case the developer tries to update it
-        // during the event. This will allow them to do so and run an update here.
-        $this->exists = true;
-
-        $this->wasRecentlyCreated = true;
-
-        $this->fireModelEvent('created', false);
-
-        return true;
-    }
-
-    /**
-     * Delete the model from the database.
-     *
-     * @return bool|null
-     */
-    public function delete()
-    {
-        $key = $this->getKey();
-
-        // If the model doesn't exist, there is nothing to delete so we'll just return
-        // immediately and not do anything else. Otherwise, we will continue with a
-        // deletion process on the model, firing the proper events, and so forth.
-        if (! $this->exists) {
-            return;
-        }
-
-        if ($this->fireModelEvent('deleting') === false) {
-            return false;
-        }
-
-        $this->newQuery()->deleteItem($key);
-
-        $this->exists = false;
-
-        // Once the model has been deleted, we will fire off the deleted event so that
-        // the developers may hook into post-delete operations. We will then return
-        // a boolean true as the delete is presumably successful on the database.
-        $this->fireModelEvent('deleted', false);
-
-        return true;
-    }
-
-    /**
-     * @inheritdoc
-     */
+    /** @inheritdoc */
     public function __call($method, $parameters)
     {
         $allowedBuilderMethods = [

--- a/src/Kitar/Dynamodb/Model/Model.php
+++ b/src/Kitar/Dynamodb/Model/Model.php
@@ -4,6 +4,7 @@ namespace Kitar\Dynamodb\Model;
 
 use Illuminate\Database\Eloquent\Model as BaseModel;
 use Kitar\Dynamodb\Model\KeyMissingException;
+use Kitar\Dynamodb\Concerns\HasMeta;
 
 class Model extends BaseModel
 {
@@ -13,6 +14,7 @@ class Model extends BaseModel
      * @var string
      */
     protected $table;
+    use HasMeta;
 
     /**
      * The Partition Key.
@@ -33,10 +35,7 @@ class Model extends BaseModel
     protected $sortKeyDefault;
 
     /**
-     * The @metadata attribute of AWS\Result response.
-     * @var mixed
      */
-    protected $meta;
 
     /**
      * @inheritdoc
@@ -324,16 +323,6 @@ class Model extends BaseModel
         $this->fireModelEvent('deleted', false);
 
         return true;
-    }
-
-    public function meta()
-    {
-        return $this->meta;
-    }
-
-    public function setMeta(array $meta)
-    {
-        $this->meta = $meta;
     }
 
     /**

--- a/src/Kitar/Dynamodb/Model/Model.php
+++ b/src/Kitar/Dynamodb/Model/Model.php
@@ -3,8 +3,8 @@
 namespace Kitar\Dynamodb\Model;
 
 use Illuminate\Database\Eloquent\Model as BaseModel;
-use Kitar\Dynamodb\Model\KeyMissingException;
 use Kitar\Dynamodb\Concerns\HasMeta;
+use Kitar\Dynamodb\Exceptions\KeyMissingException;
 
 class Model extends BaseModel
 {

--- a/src/Kitar/Dynamodb/Query/Builder.php
+++ b/src/Kitar/Dynamodb/Query/Builder.php
@@ -8,6 +8,7 @@ use Kitar\Dynamodb\Connection;
 use Kitar\Dynamodb\Query\Grammar;
 use Kitar\Dynamodb\Query\Processor;
 use Kitar\Dynamodb\Query\ExpressionAttributes;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Query\Builder as BaseBuilder;
@@ -622,5 +623,46 @@ class Builder extends BaseBuilder
         } else {
             return $response;
         }
+    }
+
+    /** LARAVEL methods */
+
+    /**
+     * Insert new records into the database.
+     *
+     * @param  array  $values
+     * @return bool
+     */
+    public function insert(array $values)
+    {
+        $result = $this->putItem(is_array($values) ? $values : func_get_args());
+
+        return count(Arr::get($result, '@metadata.transferStats')) > 0;
+    }
+
+    /**
+     * Update records in the database.
+     *
+     * @param  array  $values
+     * @return int
+     */
+    public function update($values = null)
+    {
+        $result = $this->updateItem(is_array($values) ? $values : func_get_args());
+
+        return count(Arr::get($result, '@metadata.transferStats'));
+    }
+
+    /**
+     * Delete records from the database.
+     *
+     * @param  mixed  $ids
+     * @return int
+     */
+    public function delete($ids = null)
+    {
+        $result = $this->deleteItem(is_array($ids) ? $ids : func_get_args());
+
+        return count(Arr::get($result, '@metadata.transferStats'));
     }
 }

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -122,4 +122,23 @@ class ConnectionTest extends TestCase
         $this->assertEquals($connection->getClient()->getEndpoint()->getScheme(), 'https');
         $this->assertEquals($connection->getClient()->getEndpoint()->getHost(), 'examples.com');
     }
+
+    /** @test */
+    public function it_dont_prepends_default_protocol_if_has_local_endpoint()
+    {
+        $connection = new Connection(['endpoint' => 'example-container']);
+        $this->assertEquals($connection->getClient()->getEndpoint()->getScheme(), '');
+        $this->assertEquals($connection->getClient()->getEndpoint()->getHost(), '');
+        $this->assertEquals($connection->getClient()->getEndpoint()->getPath(), 'example-container');
+    }
+
+    /** @test */
+    public function it_dont_prepends_default_protocol_if_has_local_endpoint_with_port()
+    {
+        $connection = new Connection(['endpoint' => 'example-container:8000']);
+        $this->assertEquals($connection->getClient()->getEndpoint()->getScheme(), '');
+        $this->assertEquals($connection->getClient()->getEndpoint()->getHost(), 'example-container');
+        $this->assertEquals($connection->getClient()->getEndpoint()->getPath(), '');
+        $this->assertEquals($connection->getClient()->getEndpoint()->getPort(), 8000);
+    }
 }

--- a/tests/Model/AuthUserProviderTest.php
+++ b/tests/Model/AuthUserProviderTest.php
@@ -8,7 +8,7 @@ use Mockery as m;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use Illuminate\Database\ConnectionResolver;
 use Illuminate\Hashing\BcryptHasher;
-use Kitar\Dynamodb\Model\KeyMissingException;
+use Kitar\Dynamodb\Exceptions\KeyMissingException;
 use Kitar\Dynamodb\Model\AuthUserProvider;
 
 class AuthUserProviderTest extends TestCase

--- a/tests/Model/ModelTest.php
+++ b/tests/Model/ModelTest.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\TestCase;
 use Mockery as m;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use Illuminate\Database\ConnectionResolver;
-use Kitar\Dynamodb\Model\KeyMissingException;
+use Kitar\Dynamodb\Exceptions\KeyMissingException;
 use BadMethodCallException;
 use Kitar\Dynamodb\Helpers\Collection;
 


### PR DESCRIPTION
As I mentioned in #52, the Laravel structure itself remains active, and can be extended and overwritten so that the original properties are always up to date.

This PR does not change the package's usage structure, but rather how it is integrated with eloquent to perform the tasks, reducing friction in future Laravel updates.