### PR TITLE
Add Laravel 13 and PHP 8.5 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,19 +20,19 @@
         "ci-test": "vendor/bin/phpunit --coverage-clover coverage.xml"
     },
     "require": {
-        "php": "^7.3|^7.4|^8.0|^8.1|^8.2|^8.3|^8.4",
-        "illuminate/support": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
-        "illuminate/container": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
-        "illuminate/database": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
-        "illuminate/hashing": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
+        "php": "^7.3|^7.4|^8.0|^8.1|^8.2|^8.3|^8.4|^8.5",
+        "illuminate/support": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
+        "illuminate/container": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
+        "illuminate/database": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
+        "illuminate/hashing": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
         "aws/aws-sdk-php": "^3.0"
     },
     "require-dev": {
-        "illuminate/auth": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
+        "illuminate/auth": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
         "symfony/var-dumper": "^5.0|^6.0|^7.0",
         "vlucas/phpdotenv": "^4.1|^5.0",
         "mockery/mockery": "^1.3",
-        "phpunit/phpunit": "^8.0|^9.0|^10.0"
+        "phpunit/phpunit": "^8.0|^9.0|^10.0|^11.0|^12.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,19 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
-  <coverage>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.0/phpunit.xsd" cacheDirectory=".phpunit.cache">
+  <source>
     <include>
       <directory suffix=".php">src/</directory>
     </include>
-    <report>
-      <clover outputFile="build/logs/clover.xml"/>
-      <html outputDirectory="build/html"/>
-      <text outputFile="build/coverage.txt"/>
-    </report>
-  </coverage>
+  </source>
   <testsuites>
     <testsuite name="laravel-dynamodb Test Suite">
       <directory>tests</directory>
     </testsuite>
   </testsuites>
-  <logging/>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,10 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" colors="true" processIsolation="false" stopOnFailure="false" backupStaticProperties="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.0/phpunit.xsd" cacheDirectory=".phpunit.cache">
-  <source>
-    <include>
-      <directory suffix=".php">src/</directory>
-    </include>
-  </source>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.5/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
   <coverage>
     <report>
       <clover outputFile="build/logs/clover.xml"/>
@@ -17,4 +12,10 @@
       <directory>tests</directory>
     </testsuite>
   </testsuites>
+  <logging/>
+  <source>
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+  </source>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,10 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.0/phpunit.xsd" cacheDirectory=".phpunit.cache">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" colors="true" processIsolation="false" stopOnFailure="false" backupStaticProperties="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.0/phpunit.xsd" cacheDirectory=".phpunit.cache">
   <source>
     <include>
       <directory suffix=".php">src/</directory>
     </include>
   </source>
+  <coverage>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+      <html outputDirectory="build/html"/>
+      <text outputFile="build/coverage.txt"/>
+    </report>
+  </coverage>
   <testsuites>
     <testsuite name="laravel-dynamodb Test Suite">
       <directory>tests</directory>

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -6,6 +6,7 @@ use Mockery as m;
 use Kitar\Dynamodb\Connection;
 use Kitar\Dynamodb\Query\Builder;
 use Aws\DynamoDb\DynamoDbClient;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 
@@ -25,13 +26,13 @@ class ConnectionTest extends TestCase
         m::close();
     }
 
-    /** @test */
+    #[Test]
     public function it_creates_connection()
     {
         $this->assertInstanceOf(Connection::class, $this->connection);
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_dynamodb_client()
     {
         $this->assertInstanceOf(
@@ -40,7 +41,7 @@ class ConnectionTest extends TestCase
         );
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_driver_name()
     {
         $this->assertEquals(
@@ -49,7 +50,7 @@ class ConnectionTest extends TestCase
         );
     }
 
-    /** @test */
+    #[Test]
     public function it_keeps_dynamodb_client_on_disconnect()
     {
         $this->connection->disconnect();
@@ -57,7 +58,7 @@ class ConnectionTest extends TestCase
         $this->assertNotNull($this->connection->getClient());
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_query_builder_instance()
     {
         $query = $this->connection->table('test');
@@ -67,7 +68,7 @@ class ConnectionTest extends TestCase
         $this->assertEquals('test', $query->from);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_call_client_query()
     {
         $client = m::mock(DynamoDbClient::class);
@@ -82,7 +83,7 @@ class ConnectionTest extends TestCase
         ]);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_forward_call_to_dynamodb_client()
     {
         $client = m::mock(DynamoDbClient::class);
@@ -97,7 +98,7 @@ class ConnectionTest extends TestCase
         ]);
     }
 
-    /** @test */
+    #[Test]
     public function it_prepends_default_protocol_if_not_given()
     {
         $connection = new Connection(['endpoint' => 'examples.com']);
@@ -107,7 +108,7 @@ class ConnectionTest extends TestCase
         $this->assertEquals($this->connection->getClient()->getEndpoint()->getHost(), 'dynamodb.us-east-1.amazonaws.com');
     }
 
-    /** @test */
+    #[Test]
     public function it_dont_prepends_default_protocol_if_http_given()
     {
         $connection = new Connection(['endpoint' => 'http://examples.com']);
@@ -115,7 +116,7 @@ class ConnectionTest extends TestCase
         $this->assertEquals($connection->getClient()->getEndpoint()->getHost(), 'examples.com');
     }
 
-    /** @test */
+    #[Test]
     public function it_dont_prepends_default_protocol_if_https_given()
     {
         $connection = new Connection(['endpoint' => 'https://examples.com']);

--- a/tests/Helpers/CollectionTest.php
+++ b/tests/Helpers/CollectionTest.php
@@ -3,11 +3,12 @@
 namespace Kitar\Dynamodb\Tests\Helpers;
 
 use Kitar\Dynamodb\Helpers\Collection;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 class CollectionTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function it_can_set_and_get_meta()
     {
         $items = new Collection([]);
@@ -21,7 +22,7 @@ class CollectionTest extends TestCase
         $this->assertSame($meta, $items->getMeta());
     }
 
-    /** @test */
+    #[Test]
     public function it_can_get_last_evaluated_key()
     {
         $items = new Collection([]);

--- a/tests/Helpers/NumberIteratorTest.php
+++ b/tests/Helpers/NumberIteratorTest.php
@@ -3,11 +3,12 @@
 namespace Kitar\Dynamodb\Tests\Helpers;
 
 use Kitar\Dynamodb\Helpers\NumberIterator;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 class NumberIteratorTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function it_can_use_prefix()
     {
         $iterator = new NumberIterator(1, '#');
@@ -15,7 +16,7 @@ class NumberIteratorTest extends TestCase
         $this->assertEquals('#1', $iterator->current());
     }
 
-    /** @test */
+    #[Test]
     public function it_can_increment()
     {
         $iterator = new NumberIterator(1, ':');
@@ -29,7 +30,7 @@ class NumberIteratorTest extends TestCase
         $this->assertEquals(':3', $iterator->current());
     }
 
-    /** @test */
+    #[Test]
     public function key_returns_number_without_prefix()
     {
         $iterator = new NumberIterator(1, '#');
@@ -39,7 +40,7 @@ class NumberIteratorTest extends TestCase
         $this->assertEquals(2, $iterator->key());
     }
 
-    /** @test */
+    #[Test]
     public function it_can_rewind()
     {
         $iterator = new NumberIterator(1, '#');
@@ -52,7 +53,7 @@ class NumberIteratorTest extends TestCase
         $this->assertEquals('#1', $iterator->current());
     }
 
-    /** @test */
+    #[Test]
     public function it_is_always_valid()
     {
         $iterator = new NumberIterator(1);

--- a/tests/Model/AuthUserProviderTest.php
+++ b/tests/Model/AuthUserProviderTest.php
@@ -3,6 +3,7 @@
 namespace Kitar\Dynamodb\Tests\Model;
 
 use Aws\Result;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Mockery as m;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
@@ -101,7 +102,7 @@ class AuthUserProviderTest extends TestCase
         ]);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_retrieve_by_id()
     {
         $connection = $this->newConnectionMock();
@@ -122,7 +123,7 @@ class AuthUserProviderTest extends TestCase
         $this->assertInstanceOf(UserA::class, $res);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_retrieve_by_id_with_default_sort_key()
     {
         $connection = $this->newConnectionMock();
@@ -146,7 +147,7 @@ class AuthUserProviderTest extends TestCase
         $this->assertInstanceOf(UserC::class, $res);
     }
 
-    /** @test */
+    #[Test]
     public function it_cannot_retrieve_by_id_without_default_sort_key()
     {
         $connection = $this->newConnectionMock();
@@ -159,7 +160,7 @@ class AuthUserProviderTest extends TestCase
         $provider->retrieveById('foo@bar.com');
     }
 
-    /** @test */
+    #[Test]
     public function it_cannot_retrieve_by_id_if_not_exists()
     {
         $connection = $this->newConnectionMock();
@@ -180,7 +181,7 @@ class AuthUserProviderTest extends TestCase
         $this->assertNull($res);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_retrieve_by_token()
     {
         $connection = $this->newConnectionMock();
@@ -201,7 +202,7 @@ class AuthUserProviderTest extends TestCase
         $this->assertInstanceOf(UserA::class, $res);
     }
 
-    /** @test */
+    #[Test]
     public function it_cannot_retrieve_by_token_if_not_exists()
     {
         $connection = $this->newConnectionMock();
@@ -222,7 +223,7 @@ class AuthUserProviderTest extends TestCase
         $this->assertNull($res);
     }
 
-    /** @test */
+    #[Test]
     public function it_cannot_retrieve_by_token_with_invalid_token()
     {
         $connection = $this->newConnectionMock();
@@ -243,7 +244,7 @@ class AuthUserProviderTest extends TestCase
         $this->assertNull($res);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_update_remember_token()
     {
         $connection = $this->newConnectionMock();
@@ -276,7 +277,7 @@ class AuthUserProviderTest extends TestCase
         $this->assertEquals('new_token', $user->getRememberToken());
     }
 
-    /** @test */
+    #[Test]
     public function it_can_retrieve_by_credentials_with_basic_credentials()
     {
         $connection = $this->newConnectionMock();
@@ -300,7 +301,7 @@ class AuthUserProviderTest extends TestCase
         $this->assertInstanceOf(UserA::class, $user);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_retrieve_by_credentials_with_api_token()
     {
         $connection = $this->newConnectionMock();
@@ -328,7 +329,7 @@ class AuthUserProviderTest extends TestCase
         $this->assertInstanceOf(UserA::class, $user);
     }
 
-    /** @test */
+    #[Test]
     public function it_cannot_retrieve_by_credentials_with_multiple_conditions()
     {
         $provider = new AuthUserProvider($this->hasher, UserA::class);
@@ -341,7 +342,7 @@ class AuthUserProviderTest extends TestCase
         $this->assertNull($result);
     }
 
-    /** @test */
+    #[Test]
     public function it_cannot_retrieve_by_credentials_if_key_is_not_supported()
     {
         $provider = new AuthUserProvider($this->hasher, UserA::class);
@@ -353,7 +354,7 @@ class AuthUserProviderTest extends TestCase
         $this->assertNull($result);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_validate_credentials()
     {
         $user = new UserA([
@@ -377,7 +378,7 @@ class AuthUserProviderTest extends TestCase
         $this->assertFalse($fail);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_rehash_password_if_required()
     {
         if (! method_exists(\Illuminate\Contracts\Auth\UserProvider::class, 'rehashPasswordIfRequired')) {

--- a/tests/Model/ModelTest.php
+++ b/tests/Model/ModelTest.php
@@ -3,6 +3,7 @@
 namespace Kitar\Dynamodb\Tests\Model;
 
 use Aws\Result;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Mockery as m;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
@@ -55,7 +56,7 @@ class ModelTest extends TestCase
         ]);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_create_new_instance()
     {
         $user = new UserA;
@@ -67,7 +68,7 @@ class ModelTest extends TestCase
         $this->assertEquals([], $user->attributesToArray());
     }
 
-    /** @test */
+    #[Test]
     public function it_can_create_new_instance_with_attributes()
     {
         $user = new UserB([
@@ -89,7 +90,7 @@ class ModelTest extends TestCase
         ], $user->getKey());
     }
 
-    /** @test */
+    #[Test]
     public function it_can_set_default_sort_key()
     {
         $user = new UserC;
@@ -101,7 +102,7 @@ class ModelTest extends TestCase
         $this->assertEquals($expected, $user->attributesToArray());
     }
 
-    /** @test */
+    #[Test]
     public function it_can_create_new_instance_with_overriding_sort_key()
     {
         $user = new UserC([
@@ -121,7 +122,7 @@ class ModelTest extends TestCase
         ], $user->getKey());
     }
 
-    /** @test */
+    #[Test]
     public function it_can_create_instance_with_existing_data()
     {
         // partition key only
@@ -169,7 +170,7 @@ class ModelTest extends TestCase
         ], $userC2->attributesToArray());
     }
 
-    /** @test */
+    #[Test]
     public function it_can_process_get_key_with_primary_key()
     {
         $user1 = new UserA(['partition' => 'p']);
@@ -181,7 +182,7 @@ class ModelTest extends TestCase
         $this->assertEquals(['partition' => 0], $user3->getKey());
     }
 
-    /** @test */
+    #[Test]
     public function it_can_process_get_key_with_primary_key_and_sort_key()
     {
         $user1 = new UserB(['partition' => 'p', 'sort' => 's']);
@@ -193,7 +194,7 @@ class ModelTest extends TestCase
         $this->assertEquals(['partition' => 'p', 'sort' => 0], $user3->getKey());
     }
 
-    /** @test */
+    #[Test]
     public function get_key_raise_exception_if_primary_key_is_not_defined()
     {
         $user = new UserX;
@@ -204,7 +205,7 @@ class ModelTest extends TestCase
         $user->getKey();
     }
 
-    /** @test */
+    #[Test]
     public function get_key_raise_exception_if_primary_key_is_missing()
     {
         $user = new UserA;
@@ -215,7 +216,7 @@ class ModelTest extends TestCase
         $user->getKey();
     }
 
-    /** @test */
+    #[Test]
     public function get_key_raise_exception_if_sort_key_is_missing()
     {
         $user = new UserB(['partition' => 'p']);
@@ -226,7 +227,7 @@ class ModelTest extends TestCase
         $user->getKey();
     }
 
-    /** @test */
+    #[Test]
     public function get_key_raise_exception_if_primary_and_sort_key_is_missing()
     {
         $user = new UserB();
@@ -237,7 +238,7 @@ class ModelTest extends TestCase
         $user->getKey();
     }
 
-    /** @test */
+    #[Test]
     public function it_can_process_find()
     {
         $params = [
@@ -265,7 +266,7 @@ class ModelTest extends TestCase
         $this->assertInstanceOf(UserA::class, $user);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_process_find_with_primary_key_and_sort_key()
     {
         $params = [
@@ -299,7 +300,7 @@ class ModelTest extends TestCase
         $this->assertInstanceOf(UserB::class, $user);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_process_find_with_primary_key_and_default_sort_key()
     {
         $params = [
@@ -333,7 +334,7 @@ class ModelTest extends TestCase
         $this->assertInstanceOf(UserC::class, $user);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_process_find_with_overrided_sort_key()
     {
         $params = [
@@ -370,7 +371,7 @@ class ModelTest extends TestCase
         $this->assertInstanceOf(UserC::class, $user);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_process_find_with_keys_not_exists()
     {
         $params = [
@@ -392,7 +393,7 @@ class ModelTest extends TestCase
         $this->assertNull($user);
     }
 
-    /** @test */
+    #[Test]
     public function it_cannot_process_find_with_empty_argument()
     {
         $this->expectException(KeyMissingException::class);
@@ -402,7 +403,7 @@ class ModelTest extends TestCase
         UserA::find('');
     }
 
-    /** @test */
+    #[Test]
     public function it_can_process_all()
     {
         $params = [
@@ -429,7 +430,7 @@ class ModelTest extends TestCase
         $this->assertNull($res->getLastEvaluatedKey());
     }
 
-    /** @test */
+    #[Test]
     public function it_can_get_last_evaluated_key()
     {
         $params = [
@@ -445,7 +446,7 @@ class ModelTest extends TestCase
         $this->assertSame(['id' => ['S' => '1']], $res->getLastEvaluatedKey());
     }
 
-    /** @test */
+    #[Test]
     public function it_can_save_new_instance()
     {
         $params = [
@@ -470,7 +471,7 @@ class ModelTest extends TestCase
         $user->save();
     }
 
-    /** @test */
+    #[Test]
     public function it_can_static_create_new_instance()
     {
         $params = [
@@ -493,7 +494,7 @@ class ModelTest extends TestCase
         UserD::create(['partition' => 'p']);
     }
 
-    /** @test */
+    #[Test]
     public function it_cannot_save_new_instance_without_required_key()
     {
         $connection = $this->newConnectionMock();
@@ -506,7 +507,7 @@ class ModelTest extends TestCase
         $user->save();
     }
 
-    /** @test */
+    #[Test]
     public function it_can_save_existing_instance()
     {
         $params = [
@@ -538,7 +539,7 @@ class ModelTest extends TestCase
         $user->save();
     }
 
-    /** @test */
+    #[Test]
     public function it_cannot_save_existing_instance_without_required_key()
     {
         $connection = $this->newConnectionMock();
@@ -552,7 +553,7 @@ class ModelTest extends TestCase
         $user->save();
     }
 
-    /** @test */
+    #[Test]
     public function it_can_delete_existing_instance()
     {
         $params = [
@@ -573,7 +574,7 @@ class ModelTest extends TestCase
         $user->delete();
     }
 
-    /** @test */
+    #[Test]
     public function it_cannot_delete_without_primary_keys()
     {
         $user = (new UserC)->newFromBuilder(['sort' => 's']);
@@ -583,7 +584,7 @@ class ModelTest extends TestCase
         $user->delete();
     }
 
-    /** @test */
+    #[Test]
     public function it_cannot_delete_without_sort_keys()
     {
         $user = (new UserC)->newFromBuilder(['partition' => 'p']);
@@ -593,7 +594,7 @@ class ModelTest extends TestCase
         $user->delete();
     }
 
-    /** @test */
+    #[Test]
     public function it_cannot_delete_new_instance()
     {
         $user = new UserA(['partition' => 'p']);
@@ -603,7 +604,7 @@ class ModelTest extends TestCase
         $this->assertNull($result);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_call_allowed_builder_method()
     {
         $connection = $this->newConnectionMock();
@@ -622,7 +623,7 @@ class ModelTest extends TestCase
         ]);
     }
 
-    /** @test */
+    #[Test]
     public function it_cannot_call_disallowed_builder_method()
     {
         $this->expectException(BadMethodCallException::class);

--- a/tests/Query/BuilderTest.php
+++ b/tests/Query/BuilderTest.php
@@ -10,6 +10,7 @@ use Kitar\Dynamodb\Model\Model;
 use Kitar\Dynamodb\Query\Builder;
 use Kitar\Dynamodb\Query\Grammar;
 use Kitar\Dynamodb\Query\Processor;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 
@@ -38,7 +39,7 @@ class BuilderTest extends TestCase
         return $this->connection->table($table_name)->dryRun();
     }
 
-    /** @test */
+    #[Test]
     public function dry_run_is_disabled_by_default()
     {
         $builder = (new Connection([]))->table('ProductCatalog');
@@ -46,7 +47,7 @@ class BuilderTest extends TestCase
         $this->assertFalse($builder->dry_run);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_set_index()
     {
         $params = [
@@ -76,7 +77,7 @@ class BuilderTest extends TestCase
         $this->assertEquals($params, $query['params']);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_set_key()
     {
         $params = [
@@ -93,7 +94,7 @@ class BuilderTest extends TestCase
         $this->assertEquals($params, $query['params']);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_set_limit()
     {
         $params = [
@@ -108,7 +109,7 @@ class BuilderTest extends TestCase
         $this->assertEquals($params, $query['params']);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_set_scan_index_forward()
     {
         $params = [
@@ -127,7 +128,7 @@ class BuilderTest extends TestCase
         $this->assertEquals($params, $query['params']);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_set_exclusive_start_key()
     {
         $params = [
@@ -149,7 +150,7 @@ class BuilderTest extends TestCase
         $this->assertEquals($params, $query['params']);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_set_consistent_read()
     {
         $params = [
@@ -168,7 +169,7 @@ class BuilderTest extends TestCase
         $this->assertEquals($params, $query['params']);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_set_model_class()
     {
         $query = $this->newQuery('ProductCatalog')
@@ -177,7 +178,7 @@ class BuilderTest extends TestCase
         $this->assertEquals(Product::class, $query->model_class);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_process_filter()
     {
         $params = [
@@ -199,7 +200,7 @@ class BuilderTest extends TestCase
         $this->assertEquals($params, $query['params']);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_process_filter_with_short_syntax()
     {
         $params = [
@@ -221,7 +222,7 @@ class BuilderTest extends TestCase
         $this->assertEquals($params, $query['params']);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_process_condition()
     {
         $params = [
@@ -243,7 +244,7 @@ class BuilderTest extends TestCase
         $this->assertEquals($params, $query['params']);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_process_key_condition()
     {
         $params = [
@@ -265,7 +266,7 @@ class BuilderTest extends TestCase
         $this->assertEquals($params, $query['params']);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_process_key_condition_and_filter_at_the_same_time()
     {
         $params = [
@@ -299,7 +300,7 @@ class BuilderTest extends TestCase
         $this->assertEquals($params, $query['params']);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_process_or_filter()
     {
         $params = [
@@ -326,7 +327,7 @@ class BuilderTest extends TestCase
         $this->assertEquals($params, $query['params']);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_process_or_condition()
     {
         $params = [
@@ -351,7 +352,7 @@ class BuilderTest extends TestCase
         $this->assertEquals($params, $query['params']);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_process_filter_in()
     {
         $params = [
@@ -380,7 +381,7 @@ class BuilderTest extends TestCase
         $this->assertEquals($params, $query['params']);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_process_filter_between()
     {
         $params = [
@@ -406,7 +407,7 @@ class BuilderTest extends TestCase
         $this->assertEquals($params, $query['params']);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_process_nested_filters()
     {
         $params = [
@@ -453,7 +454,7 @@ class BuilderTest extends TestCase
         $this->assertEquals($params, $query['params']);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_process_attribute_exists_function()
     {
         $params = [
@@ -471,7 +472,7 @@ class BuilderTest extends TestCase
         $this->assertEquals($params, $query['params']);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_process_attribute_not_exists_function()
     {
         $params = [
@@ -489,7 +490,7 @@ class BuilderTest extends TestCase
         $this->assertEquals($params, $query['params']);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_process_attribute_type_function()
     {
         $params = [
@@ -512,7 +513,7 @@ class BuilderTest extends TestCase
         $this->assertEquals($params, $query['params']);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_process_begins_with_function()
     {
         $params = [
@@ -535,7 +536,7 @@ class BuilderTest extends TestCase
         $this->assertEquals($params, $query['params']);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_process_contains_function()
     {
         $params = [
@@ -558,7 +559,7 @@ class BuilderTest extends TestCase
         $this->assertEquals($params, $query['params']);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_process_get_item()
     {
         $method = 'getItem';
@@ -580,7 +581,7 @@ class BuilderTest extends TestCase
         $this->assertEquals($processor, $query['processor']);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_process_get_item_with_key()
     {
         $params = [
@@ -597,7 +598,7 @@ class BuilderTest extends TestCase
         $this->assertEquals($params, $query['params']);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_process_get_item_with_expressions()
     {
         $params = [
@@ -620,7 +621,7 @@ class BuilderTest extends TestCase
         $this->assertEquals($params, $query['params']);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_process_put_item()
     {
         $method = 'putItem';
@@ -646,7 +647,7 @@ class BuilderTest extends TestCase
         $this->assertNull($query['processor']);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_process_delete_item()
     {
         $method = 'deleteItem';
@@ -672,7 +673,7 @@ class BuilderTest extends TestCase
         $this->assertNull($query['processor']);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_process_update_item()
     {
         $method = 'updateItem';
@@ -721,7 +722,7 @@ class BuilderTest extends TestCase
         $this->assertEquals($processor, $query['processor']);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_process_batch_get_item()
     {
         $method = 'batchGetItem';
@@ -769,7 +770,7 @@ class BuilderTest extends TestCase
         $this->assertEquals($processor, $query['processor']);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_process_batch_put_item()
     {
         $method = 'batchWriteItem';
@@ -822,7 +823,7 @@ class BuilderTest extends TestCase
         $this->assertNull($query['processor']);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_process_batch_delete_item()
     {
         $method = 'batchWriteItem';
@@ -875,7 +876,7 @@ class BuilderTest extends TestCase
         $this->assertNull($query['processor']);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_process_batch_write_item()
     {
         $method = 'batchWriteItem';
@@ -936,7 +937,7 @@ class BuilderTest extends TestCase
         $this->assertNull($query['processor']);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_increment_value_of_attribute()
     {
         $method = 'updateItem';
@@ -981,7 +982,7 @@ class BuilderTest extends TestCase
         $this->assertEquals($processor, $query['processor']);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_decrement_value_of_attribute()
     {
         $method = 'updateItem';
@@ -1026,7 +1027,7 @@ class BuilderTest extends TestCase
         $this->assertEquals($processor, $query['processor']);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_set_single_attribute()
     {
         $query = $this->newQuery('Thread')
@@ -1043,7 +1044,7 @@ class BuilderTest extends TestCase
         );
     }
 
-    /** @test */
+    #[Test]
     public function it_can_set_multiple_attributes()
     {
         $query = $this->newQuery('Thread')
@@ -1061,7 +1062,7 @@ class BuilderTest extends TestCase
         );
     }
 
-    /** @test */
+    #[Test]
     public function it_can_remove_single_attribute()
     {
         $query = $this->newQuery('Thread')
@@ -1078,7 +1079,7 @@ class BuilderTest extends TestCase
         );
     }
 
-    /** @test */
+    #[Test]
     public function it_can_remove_multiple_attributes()
     {
         $query = $this->newQuery('Thread')
@@ -1096,7 +1097,7 @@ class BuilderTest extends TestCase
         );
     }
 
-    /** @test */
+    #[Test]
     public function it_can_process_query()
     {
         $method = 'clientQuery';
@@ -1122,7 +1123,7 @@ class BuilderTest extends TestCase
         $this->assertEquals($processor, $query['processor']);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_process_scan()
     {
         $method = 'scan';
@@ -1139,7 +1140,7 @@ class BuilderTest extends TestCase
         $this->assertEquals($processor, $query['processor']);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_process_scan_with_columns_specified()
     {
         $method = 'scan';
@@ -1161,7 +1162,7 @@ class BuilderTest extends TestCase
         $this->assertEquals($processor, $query['processor']);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_process_process()
     {
         $connection = m::mock(Connection::class);
@@ -1176,7 +1177,7 @@ class BuilderTest extends TestCase
         $query->from('Forum')->scan();
     }
 
-    /** @test */
+    #[Test]
     public function it_can_process_process_with_no_processor()
     {
         $connection = m::mock(Connection::class);
@@ -1202,7 +1203,7 @@ class BuilderTest extends TestCase
         ]);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_forward_call_to_unknown_method()
     {
         $query = $this->newQuery('Thread');
@@ -1212,7 +1213,7 @@ class BuilderTest extends TestCase
         $query->filterNotIn(['foo', 'bar']);
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_prefixed_builder()
     {
         $connection = new Connection(['prefix' => 'my_table_prefix_']);

--- a/tests/Query/ProcessorTest.php
+++ b/tests/Query/ProcessorTest.php
@@ -5,6 +5,7 @@ namespace Kitar\Dynamodb\Tests\Query;
 use Aws\Result;
 use Kitar\Dynamodb\Model\Model;
 use Kitar\Dynamodb\Query\Processor;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 class User extends Model
@@ -35,7 +36,7 @@ class ProcessorTest extends TestCase
         $this->processor = new Processor;
     }
 
-    /** @test */
+    #[Test]
     public function it_can_process_single_item_result()
     {
         $expected = json_decode($this->mocks['single_item_processed'], true);
@@ -47,7 +48,7 @@ class ProcessorTest extends TestCase
         $this->assertEquals($expected, $item);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_process_single_item_empty_result()
     {
         $expected = json_decode($this->mocks['single_item_empty_processed'], true);
@@ -59,7 +60,7 @@ class ProcessorTest extends TestCase
         $this->assertEquals($expected, $item);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_process_multiple_items_result()
     {
         $expected = json_decode($this->mocks['multiple_items_processed'], true);
@@ -71,7 +72,7 @@ class ProcessorTest extends TestCase
         $this->assertEquals($expected, $items);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_process_multiple_items_empty_result()
     {
         $expected = json_decode($this->mocks['multiple_items_empty_processed'], true);
@@ -83,7 +84,7 @@ class ProcessorTest extends TestCase
         $this->assertEquals($expected, $items);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_process_batch_get_items_result()
     {
         $expected = json_decode($this->mocks['batch_get_items_processed'], true);
@@ -95,7 +96,7 @@ class ProcessorTest extends TestCase
         $this->assertEquals($expected, $items);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_process_batch_get_items_empty_result()
     {
         $expected = json_decode($this->mocks['batch_get_items_empty_processed'], true);
@@ -107,7 +108,7 @@ class ProcessorTest extends TestCase
         $this->assertEquals($expected, $items);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_convert_single_result_to_model_instance()
     {
         $awsResult = new Result(json_decode($this->mocks['single_item_result'], true));
@@ -125,7 +126,7 @@ class ProcessorTest extends TestCase
         $this->assertEquals(200, $item->meta()['@metadata']['statusCode']);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_convert_multiple_results_to_model_instance()
     {
         $awsResult = new Result(json_decode($this->mocks['multiple_items_result'], true));
@@ -142,7 +143,7 @@ class ProcessorTest extends TestCase
         $this->assertEquals(200, $item->meta()['@metadata']['statusCode']);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_convert_batch_get_results_to_model_instance()
     {
         $awsResult = new Result(json_decode($this->mocks['batch_get_items_result'], true));


### PR DESCRIPTION
## Summary

- Adds `^13.0` to all `illuminate/*` package constraints (`support`, `container`, `database`, `hashing`, `auth`)
- Adds `^8.5` to the PHP version constraint
- Adds `^11.0|^12.0` to the `phpunit/phpunit` dev constraint
- Migrates `phpunit.xml.dist` to PHPUnit 12 schema using `--migrate-configuration`
- Replaces `@test` docblock annotations with `#[Test]` attributes (required by PHPUnit 10+)

## Test plan

- [ ] Verify existing tests pass against Laravel 13
- [ ] Verify existing tests pass against PHP 8.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)