### PR TITLE
Feat/laravel 13 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,20 +23,20 @@
         "ci-test": "vendor/bin/phpunit --testsuite Unit,Feature --coverage-clover coverage.xml"
     },
     "require": {
-        "php": "^8.2",
-        "illuminate/support": "^12.0",
-        "illuminate/container": "^12.0",
-        "illuminate/database": "^12.0",
-        "illuminate/hashing": "^12.0",
+        "php": "^8.2|^8.3|^8.4|^8.5",
+        "illuminate/support": "^12.0|^13.0",
+        "illuminate/container": "^12.0|^13.0",
+        "illuminate/database": "^12.0|^13.0",
+        "illuminate/hashing": "^12.0|^13.0",
         "aws/aws-sdk-php": "^3.0"
     },
     "require-dev": {
-        "illuminate/auth": "^12.0",
-        "orchestra/testbench": "^10.0",
+        "illuminate/auth": "^12.0|^13.0",
+        "orchestra/testbench": "^10.0|^11.0",
         "symfony/var-dumper": "^7.0",
         "vlucas/phpdotenv": "^5.0",
         "mockery/mockery": "^1.6",
-        "phpunit/phpunit": "^11.0",
+        "phpunit/phpunit": "^11.0|^12.0",
         "laravel/pint": "^1.27"
     },
     "autoload": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,10 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" colors="true" processIsolation="false" stopOnFailure="false" backupStaticProperties="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.0/phpunit.xsd" cacheDirectory=".phpunit.cache">
-  <source>
-    <include>
-      <directory suffix=".php">src/</directory>
-    </include>
-  </source>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.5/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
   <coverage>
     <report>
       <clover outputFile="build/logs/clover.xml"/>
@@ -23,4 +18,10 @@
       <directory>tests/Integration</directory>
     </testsuite>
   </testsuites>
+  <logging/>
+  <source>
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+  </source>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,10 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.0/phpunit.xsd" cacheDirectory=".phpunit.cache">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" colors="true" processIsolation="false" stopOnFailure="false" backupStaticProperties="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.0/phpunit.xsd" cacheDirectory=".phpunit.cache">
   <source>
     <include>
       <directory suffix=".php">src/</directory>
     </include>
   </source>
+  <coverage>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+      <html outputDirectory="build/html"/>
+      <text outputFile="build/coverage.txt"/>
+    </report>
+  </coverage>
   <testsuites>
     <testsuite name="Unit">
       <directory>tests/Unit</directory>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.0/phpunit.xsd" cacheDirectory=".phpunit.cache">
   <source>
     <include>
       <directory suffix=".php">src/</directory>


### PR DESCRIPTION
This extends the `v2.x-dev` branch with Laravel 13 and PHPUnit 12 support, [originally opened here](https://github.com/kitar/laravel-dynamodb/pull/58) by @danclarkdev against `main` and rebased onto `v2.x-dev` as requested by @kitar .

As requested, I've tested this against a Laravel app upgraded to Laravel 13 with a local DynamoDB instance. Our app uses this package only for writes, so that's the scenario I was able to verify — writes complete successfully.

The illuminate/* package constraints and testbench are widened to accept v13, the PHP constraint is expanded to explicitly include 8.3–8.5, and PHPUnit is updated to support v12 — including migrating `phpunit.xml.dist` to the PHPUnit 12 schema.