### PR TITLE
fix: strip null attributes from `putItem` and `batchPutItem` to prevent `ValidationException`

### DIFF
--- a/src/Kitar/Dynamodb/Model/Model.php
+++ b/src/Kitar/Dynamodb/Model/Model.php
@@ -266,7 +266,7 @@ class Model extends BaseModel
             $this->updateTimestamps();
         }
 
-        $attributes = $this->getAttributes();
+        $attributes = array_filter($this->getAttributes(), static fn ($value) => $value !== null);
 
         // If the table isn't incrementing we'll simply insert these attributes as they
         // are. These attribute arrays must contain an "id" column previously placed

--- a/src/Kitar/Dynamodb/Model/Model.php
+++ b/src/Kitar/Dynamodb/Model/Model.php
@@ -268,6 +268,11 @@ class Model extends BaseModel
 
         $attributes = array_filter($this->getAttributes(), static function ($value) { return $value !== null; });
 
+        // Validate the key before the early-return guard so that KeyMissingException
+        // is always thrown when a required key attribute is absent or null, even if
+        // all other attributes are also null and $attributes ends up empty.
+        $key = $this->getKey();
+
         // If the table isn't incrementing we'll simply insert these attributes as they
         // are. These attribute arrays must contain an "id" column previously placed
         // there by the developer as the manually determined key for these models.
@@ -276,7 +281,7 @@ class Model extends BaseModel
         }
 
         // Prevent overwrites of an existing item.
-        foreach (array_keys($this->getKey()) as $keyName) {
+        foreach (array_keys($key) as $keyName) {
             $query = $query->condition($keyName, 'attribute_not_exists');
         }
 

--- a/src/Kitar/Dynamodb/Model/Model.php
+++ b/src/Kitar/Dynamodb/Model/Model.php
@@ -266,7 +266,7 @@ class Model extends BaseModel
             $this->updateTimestamps();
         }
 
-        $attributes = array_filter($this->getAttributes(), static fn ($value) => $value !== null);
+        $attributes = array_filter($this->getAttributes(), static function ($value) { return $value !== null; });
 
         // If the table isn't incrementing we'll simply insert these attributes as they
         // are. These attribute arrays must contain an "id" column previously placed

--- a/src/Kitar/Dynamodb/Query/Builder.php
+++ b/src/Kitar/Dynamodb/Query/Builder.php
@@ -338,7 +338,10 @@ class Builder extends BaseBuilder
         $this->batch_write_request_items = collect($items)->map(function ($item) {
             return [
                 'PutRequest' => [
-                    'Item' => $item,
+                    // Strip null values: absent attributes are semantically equivalent
+                    // to null in DynamoDB, and putItem rejects {"NULL": true} for typed
+                    // key attributes (S/N/B) with a ValidationException.
+                    'Item' => array_filter($item, static function ($value) { return $value !== null; }),
                 ],
             ];
         })->toArray();

--- a/tests/Model/ModelTest.php
+++ b/tests/Model/ModelTest.php
@@ -471,6 +471,34 @@ class ModelTest extends TestCase
     }
 
     /** @test */
+    public function it_strips_null_attributes_from_putItem_on_insert()
+    {
+        $params = [
+            'TableName' => 'User',
+            'Item' => [
+                'partition' => [
+                    'S' => 'p'
+                ]
+                // 'name' must NOT appear: null attributes must be omitted,
+                // otherwise the Marshaler converts them to {"NULL":true} which
+                // DynamoDB rejects for typed key attributes (S/N/B).
+            ],
+            'ConditionExpression' => 'attribute_not_exists(#1)',
+            'ExpressionAttributeNames' => [
+                '#1' => 'partition'
+            ]
+        ];
+
+        $connection = $this->newConnectionMock();
+        $connection->shouldReceive('putItem')->with($params)->once();
+        $this->setConnectionResolver($connection);
+
+        $user = new UserA(['partition' => 'p', 'name' => null]);
+        $user->timestamps = false;
+        $user->save();
+    }
+
+    /** @test */
     public function it_can_static_create_new_instance()
     {
         $params = [

--- a/tests/Query/BuilderTest.php
+++ b/tests/Query/BuilderTest.php
@@ -823,6 +823,43 @@ class BuilderTest extends TestCase
     }
 
     /** @test */
+    public function it_strips_null_attributes_from_each_item_in_batch_put_item()
+    {
+        $method = 'batchWriteItem';
+        $params = [
+            'TableName' => 'Thread',
+            'RequestItems' => [
+                'Thread' => [
+                    [
+                        'PutRequest' => [
+                            'Item' => [
+                                'ForumName' => [
+                                    'S' => 'Amazon DynamoDB'
+                                ]
+                                // 'Subject' must NOT appear: null attributes must be
+                                // omitted to avoid {"NULL":true} ValidationException.
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+        ];
+
+        $query = $this->newQuery('Thread')
+            ->dryRun()
+            ->batchPutItem([
+                [
+                    'ForumName' => 'Amazon DynamoDB',
+                    'Subject' => null
+                ]
+            ]);
+
+        $this->assertEquals($method, $query['method']);
+        $this->assertEquals($params, $query['params']);
+        $this->assertNull($query['processor']);
+    }
+
+    /** @test */
     public function it_can_process_batch_delete_item()
     {
         $method = 'batchWriteItem';


### PR DESCRIPTION
## Problem

When a model attribute is set to `null` (e.g. an optional accessor that maps to a GSI key), `performInsert` passes it through to `putItem`. The AWS Marshaler converts PHP `null` to the DynamoDB `NULL` type (`{"NULL": true}`). DynamoDB rejects this with:

```
ValidationException (client): Invalid attribute value type
```

This happens because attributes referenced in a table's `AttributeDefinitions` (table keys, GSI keys) must be of the declared type (`S`, `N`, or `B`). Providing `{"NULL": true}` for a `String`-typed GSI key attribute is invalid.

The `updateItem` path is **not** affected — it already handles `null` correctly by emitting a [`REMOVE` expression](https://github.com/kitar/laravel-dynamodb/blob/main/src/Kitar/Dynamodb/Query/Builder.php#L316-L317) instead of a `SET`, which properly removes the attribute from the item.

## Root Cause

`performInsert` [calls `$this->getAttributes()`](https://github.com/kitar/laravel-dynamodb/blob/main/src/Kitar/Dynamodb/Model/Model.php#L269) and forwards the full result — including any `null` values — to `putItem`. The Marshaler has no awareness of the table schema and faithfully converts every `null` to `{"NULL": true}`, producing an item that DynamoDB rejects.

`batchPutItem` is affected by the same bug. Items are passed directly to the AWS Marshaler without null filtering, so any `null` attribute in a batch item is also marshaled to `{"NULL": true}` and triggers the same `ValidationException`.

In DynamoDB, an absent attribute and a `null` attribute are semantically equivalent from the application's perspective. There is no reason to store `{"NULL": true}` for an attribute that has no value; it should simply be omitted from the item.

## Fix

Filter `null` values before passing attributes to DynamoDB. Falsy-but-non-null values (`false`, `0`, `""`) are preserved.

**`Model::performInsert`** (ORM insert path):

```php
// Before
$attributes = $this->getAttributes();

// After
$attributes = array_filter($this->getAttributes(), static function ($value) { return $value !== null; });
```

**`Builder::batchPutItem`** (direct query-builder path):

```php
// Before
'Item' => $item,

// After
'Item' => array_filter($item, static function ($value) { return $value !== null; }),
```

> `false`, `0`, `""` and other falsy-but-non-null values are preserved.

## Minimal Reproduction

This isn't about deliberately calling `create(['GSI1PK' => null])`. It happens naturally in two common scenarios:

- **Laravel's `ConvertEmptyStringsToNull` middleware** converts every blank form field to `null` before it reaches the controller, so any optional input left empty arrives as `null` in `$request->validated()`.
- **Nullable mutators that map user-facing attributes to GSI keys** for write symmetry (the same setter is reused on both create and update). When the optional attribute is absent on create, the setter is still called with `null` and explicitly sets the GSI key to `null` in `$attributes`.

**Table schema** (`GSI1PK` is defined as String type — DynamoDB rejects `{"NULL": true}` for it):

```yaml
Resources:
  PostsTable:
    Type: AWS::DynamoDB::Table
    Properties:
      TableName: posts
      BillingMode: PAY_PER_REQUEST
      AttributeDefinitions:
        - AttributeName: PK
          AttributeType: S
        - AttributeName: SK
          AttributeType: S
        - AttributeName: GSI1PK     # <-- String type; NULL is not valid here
          AttributeType: S
      KeySchema:
        - AttributeName: PK
          KeyType: HASH
        - AttributeName: SK
          KeyType: RANGE
      GlobalSecondaryIndexes:
        - IndexName: GSI1
          KeySchema:
            - AttributeName: GSI1PK
              KeyType: HASH
          Projection:
            ProjectionType: ALL
```

**Model:**

```php
use Illuminate\Database\Eloquent\Casts\Attribute;
use Kitar\Dynamodb\Model\Model;

class Post extends Model
{
    protected $table      = 'posts';
    protected $primaryKey = 'PK';
    protected $sortKey    = 'SK';
    protected $fillable   = ['title', 'slug'];

    public function slug(): Attribute
    {
        return Attribute::make(
            get: fn () => $this->GSI1PK,
            set: static fn (?string $value): array => $value === null
                ? ['GSI1PK' => null]   // null when no slug
                : ['GSI1PK' => $value],
        );
    }
}

// Creating a post without a slug sets GSI1PK = null in $attributes.
// putItem marshals it as {"NULL": true}, which DynamoDB rejects with:
// ValidationException: Invalid attribute value type
Post::create(['title' => 'Hello World', 'slug' => null]);
```

**Expected:** item is created; `GSI1PK` is simply absent from the stored item.  
**Actual:** `ValidationException (client): Invalid attribute value type`

---

The **update** flow already works correctly. When a `null` attribute appears in `getDirty()`, `performUpdate` passes it to `updateItem`, which [routes it to a `REMOVE` expression](https://github.com/kitar/laravel-dynamodb/blob/main/src/Kitar/Dynamodb/Query/Builder.php#L316-L317) — properly removing the attribute from the stored item instead of writing an invalid `{"NULL": true}`:

```php
// Updating an existing post to remove its slug:
$post = Post::find(['PK' => 'post#1', 'SK' => 'post#1']);
$post->slug = null;
$post->save();

// performUpdate → getDirty() = ['GSI1PK' => null]
// updateItem(['GSI1PK' => null])
//   → REMOVE GSI1PK            ✓  attribute is deleted from the item
//   (not SET GSI1PK = {"NULL": true}, which would fail the same way)
```
